### PR TITLE
Измененная обработка тегов

### DIFF
--- a/multimeter/models.py
+++ b/multimeter/models.py
@@ -167,6 +167,8 @@ class Problem(Model):
         for tag in tags_to_del:
             tag_object, _ = Tag.objects.get_or_create(tag=tag)
             tag_object.problems.remove(self)
+            if tag_object.problems.count() == 0:
+                tag_object.delete()
 
 
 class ContestProblem(Model):

--- a/multimeter/models.py
+++ b/multimeter/models.py
@@ -148,20 +148,22 @@ class Problem(Model):
     def __str__(self):
         return self.name
 
-    def set_tags(self, new_tags: str):
+    def set_tags_from_string(self, new_tags: str):
         """ Сохранение измененного списка тегов """
         new_tags = new_tags.lower()
         new_tags = ' '.join(new_tags.split())
         new_tags = set(new_tags.split(','))
+        self.set_tags(new_tags)
 
+    def set_tags(self, tags: set):
         old_tags = {t.tag for t in self.tags.all()}
 
-        tags_to_add = new_tags - old_tags
+        tags_to_add = tags - old_tags
         for tag in tags_to_add:
             tag_object, _ = Tag.objects.get_or_create(tag=tag)
             tag_object.problems.add(self)
 
-        tags_to_del = old_tags - new_tags
+        tags_to_del = old_tags - tags
         for tag in tags_to_del:
             tag_object, _ = Tag.objects.get_or_create(tag=tag)
             tag_object.problems.remove(self)

--- a/multimeter/models.py
+++ b/multimeter/models.py
@@ -151,8 +151,8 @@ class Problem(Model):
     def set_tags(self, new_tags: str):
         """ Сохранение измененного списка тегов """
         new_tags = new_tags.lower()
-        new_tags = new_tags.replace(',', ' ')
-        new_tags = set(new_tags.split())
+        new_tags = ' '.join(new_tags.split())
+        new_tags = set(new_tags.split(','))
 
         old_tags = {t.tag for t in self.tags.all()}
 

--- a/multimeter/templates/multimeter/problem_form.html
+++ b/multimeter/templates/multimeter/problem_form.html
@@ -25,7 +25,7 @@
 								<div class="form-group col" data-form="name"></div>
 								<div class="form-group col" data-form="tags">
 									<small class="form-text text-muted">
-	  									Тег — это слово в нижнем регистре. Теги должны быть разделены пробелами.
+	  									Тег — это предложение в нижнем регистре. Теги должны быть разделены запятыми.
 									</small>
 								</div>
 							</div>

--- a/multimeter/views.py
+++ b/multimeter/views.py
@@ -121,7 +121,7 @@ def problem_edit_page(request, problem_id=None):
         form = ProblemForm(request.POST, instance=problem)
         if form.is_valid():
             problem = form.save()
-            problem.set_tags(form.cleaned_data['tags'])
+            problem.set_tags_from_string(form.cleaned_data['tags'])
             return redirect('problem_list')
     else:
         form = ProblemForm(initial=initial, instance=problem)

--- a/multimeter/views.py
+++ b/multimeter/views.py
@@ -115,7 +115,7 @@ def problem_edit_page(request, problem_id=None):
     problem = None if problem_id is None else get_object_or_404(Problem, pk=problem_id)
     initial = {
         'author': request.user if problem is None else problem.author,
-        'tags': '' if problem is None else ' '.join([t.tag for t in problem.tags.all()])
+        'tags': '' if problem is None else ','.join([t.tag for t in problem.tags.all()])
     }
     if request.method == 'POST':
         form = ProblemForm(request.POST, instance=problem)


### PR DESCRIPTION
Для поддержки тегов, состоящих из двух и более слов. В качестве разделится тегов теперь запятая.
Метод `set_tags` теперь принимает `set` и является основной при работе с тегами.
Для установки тегов из строки теперь используется `set_tags_from_string`. 